### PR TITLE
Add Glue streaming ETL from Kinesis to S3 and downstream stream

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,38 @@
-# aws-data-engineering-etl
+# AWS Data Engineering ETL
+
+This project provides an AWS Glue job that reads JSON records from an AWS Kinesis Data Stream, enriches each record, writes the processed data to Amazon S3 in a date-partitioned layout, and publishes the transformed records to a new Kinesis stream.
+
+## Folder Structure
+
+```
+src/
+    config.py
+    jobs/
+        glue_job.py
+    processing/
+        transformer.py
+    utils/
+        kinesis.py
+        s3.py
+```
+
+## Deployment
+
+1. Package the contents of `src` and upload to an S3 location accessible by AWS Glue.
+2. Create an AWS Glue job (Python 3) and set the job script to `src/jobs/glue_job.py`.
+3. Supply job parameters for configuration:
+   - `--INPUT_STREAM` name of the source Kinesis stream.
+   - `--OUTPUT_STREAM` name of the destination Kinesis stream.
+   - `--S3_BUCKET` name of the target S3 bucket.
+   - `--AWS_REGION` AWS region, defaults to `us-east-1`.
+4. Attach an IAM role with permissions for Kinesis read/write and S3 write operations.
+
+## Running
+
+When the job runs in AWS Glue it will:
+
+1. Read records from the input stream.
+2. Enrich each record with computed fields.
+3. Store the results under `s3://<bucket>/processed/yyyy/mm/dd/`.
+4. Publish the enriched records to the output stream for downstream consumers.
+

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,0 +1,1 @@
+"""ETL package."""

--- a/src/config.py
+++ b/src/config.py
@@ -1,0 +1,22 @@
+from dataclasses import dataclass
+import os
+
+@dataclass
+class Config:
+    region: str
+    input_stream: str
+    output_stream: str
+    bucket: str
+
+def load_config() -> Config:
+    """Load configuration from environment variables.
+
+    Returns:
+        Config: Loaded configuration containing region, input stream, output stream, and bucket.
+    """
+    return Config(
+        region=os.environ.get("AWS_REGION", "us-east-1"),
+        input_stream=os.environ["INPUT_STREAM"],
+        output_stream=os.environ["OUTPUT_STREAM"],
+        bucket=os.environ["S3_BUCKET"]
+    )

--- a/src/jobs/__init__.py
+++ b/src/jobs/__init__.py
@@ -1,0 +1,1 @@
+"""Job entrypoints."""

--- a/src/jobs/glue_job.py
+++ b/src/jobs/glue_job.py
@@ -1,0 +1,25 @@
+import logging
+from typing import Dict, List
+from config import load_config
+from utils import kinesis as kin
+from utils import s3 as s3_util
+from processing.transformer import enrich_record
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+def run() -> None:
+    """Execute the streaming ETL job.
+
+    Returns:
+        None
+    """
+    config = load_config()
+    kin_client = kin.get_client(config.region)
+    s3_client = s3_util.get_client(config.region)
+    raw_records = kin.read_records(kin_client, config.input_stream)
+    transformed: List[Dict] = []
+    for r in raw_records:
+        transformed.append({"data": enrich_record(r["data"]), "partition_key": r["partition_key"]})
+    s3_util.write_json_records(s3_client, config.bucket, "processed", [r["data"] for r in transformed])
+    kin.put_records(kin_client, config.output_stream, transformed)

--- a/src/processing/__init__.py
+++ b/src/processing/__init__.py
@@ -1,0 +1,1 @@
+"""Data transformation modules."""

--- a/src/processing/transformer.py
+++ b/src/processing/transformer.py
@@ -1,0 +1,18 @@
+from datetime import datetime
+from typing import Any, Dict
+
+def enrich_record(record: Dict[str, Any]) -> Dict[str, Any]:
+    """Enrich a record with computed fields.
+
+    Args:
+        record (Dict[str, Any]): Original record to process.
+
+    Returns:
+        Dict[str, Any]: Transformed record containing additional fields.
+    """
+    result = dict(record)
+    result["processed_at"] = datetime.utcnow().isoformat()
+    value = record.get("value")
+    if isinstance(value, (int, float)):
+        result["value_squared"] = value ** 2
+    return result

--- a/src/utils/__init__.py
+++ b/src/utils/__init__.py
@@ -1,0 +1,1 @@
+"""Utility modules."""

--- a/src/utils/kinesis.py
+++ b/src/utils/kinesis.py
@@ -1,0 +1,80 @@
+import json
+import logging
+import time
+from typing import List, Dict
+import boto3
+from botocore.exceptions import ClientError
+
+logger = logging.getLogger(__name__)
+
+def get_client(region: str) -> boto3.client:
+    """Create Kinesis client.
+
+    Args:
+        region (str): AWS region for the client.
+
+    Returns:
+        boto3.client: Kinesis client instance.
+    """
+    return boto3.client("kinesis", region_name=region)
+
+def read_records(client, stream_name: str, limit: int = 100) -> List[Dict]:
+    """Read records from a Kinesis stream.
+
+    Args:
+        client (boto3.client): Kinesis client instance.
+        stream_name (str): Name of the stream to read from.
+        limit (int): Maximum number of records to fetch.
+
+    Returns:
+        List[Dict]: Parsed records containing data and partition key.
+    """
+    for attempt in range(3):
+        try:
+            response = client.describe_stream(StreamName=stream_name)
+            shards = response["StreamDescription"]["Shards"]
+            break
+        except ClientError as exc:
+            logger.error("Describe stream failed: %s", exc)
+            time.sleep(2 ** attempt)
+    else:
+        raise RuntimeError("Unable to describe Kinesis stream")
+    records: List[Dict] = []
+    for shard in shards:
+        shard_id = shard["ShardId"]
+        iterator = client.get_shard_iterator(StreamName=stream_name, ShardId=shard_id, ShardIteratorType="TRIM_HORIZON")["ShardIterator"]
+        while iterator and len(records) < limit:
+            out = client.get_records(ShardIterator=iterator, Limit=min(limit - len(records), 100))
+            iterator = out.get("NextShardIterator")
+            records.extend(out.get("Records", []))
+            if not out.get("Records"):
+                time.sleep(1.0)
+    parsed: List[Dict] = []
+    for item in records:
+        data = json.loads(item["Data"].decode())
+        parsed.append({"data": data, "partition_key": item["PartitionKey"]})
+    return parsed
+
+def put_records(client, stream_name: str, records: List[Dict]) -> None:
+    """Write records to a Kinesis stream.
+
+    Args:
+        client (boto3.client): Kinesis client instance.
+        stream_name (str): Name of the stream to write to.
+        records (List[Dict]): Records to publish.
+
+    Returns:
+        None
+    """
+    entries = []
+    for record in records:
+        data_bytes = json.dumps(record["data"]).encode()
+        entries.append({"Data": data_bytes, "PartitionKey": record.get("partition_key", "default")})
+    for attempt in range(3):
+        try:
+            client.put_records(StreamName=stream_name, Records=entries)
+            return
+        except ClientError as exc:
+            logger.error("Put records failed: %s", exc)
+            time.sleep(2 ** attempt)
+    raise RuntimeError("Unable to write records to Kinesis")

--- a/src/utils/s3.py
+++ b/src/utils/s3.py
@@ -1,0 +1,44 @@
+import json
+import logging
+import time
+from datetime import datetime
+from typing import List, Dict
+import boto3
+from botocore.exceptions import ClientError
+
+logger = logging.getLogger(__name__)
+
+def get_client(region: str) -> boto3.client:
+    """Create S3 client.
+
+    Args:
+        region (str): AWS region for the client.
+
+    Returns:
+        boto3.client: S3 client instance.
+    """
+    return boto3.client("s3", region_name=region)
+
+def write_json_records(client, bucket: str, prefix: str, records: List[Dict]) -> str:
+    """Write JSON records to S3 with date partitioning.
+
+    Args:
+        client (boto3.client): S3 client instance.
+        bucket (str): Bucket to write to.
+        prefix (str): Base key prefix.
+        records (List[Dict]): Records to serialize.
+
+    Returns:
+        str: S3 URI of the stored object.
+    """
+    now = datetime.utcnow()
+    key = f"{prefix}/{now.year:04d}/{now.month:02d}/{now.day:02d}/data_{now.strftime('%H%M%S%f')}.json"
+    body = "\n".join(json.dumps(r) for r in records)
+    for attempt in range(3):
+        try:
+            client.put_object(Bucket=bucket, Key=key, Body=body.encode())
+            return f"s3://{bucket}/{key}"
+        except ClientError as exc:
+            logger.error("Put object failed: %s", exc)
+            time.sleep(2 ** attempt)
+    raise RuntimeError("Unable to write records to S3")


### PR DESCRIPTION
## Summary
- add modular Glue job that reads from a Kinesis stream, enriches data, writes to S3 partitions, and republishes to a new stream
- provide reusable utilities for Kinesis, S3, and record transformation
- document deployment and execution steps for AWS Glue

## Testing
- `python -m py_compile $(find src -name '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68ad634591d08333b6e02a5a817883a5